### PR TITLE
Use '#' for comments

### DIFF
--- a/syntax/mdc.vim
+++ b/syntax/mdc.vim
@@ -8,7 +8,7 @@ syn keyword mdcFlash drawflush printflush
 syn keyword mdcKeyword getlink control radar sensor
 syn keyword mdcStructure set
 syn match mdcNumber "\v\d*"
-syn match mdcComment "\v//.*$"
+syn match mdcComment "\v#.*$"
 
 hi def link mdcConditional Conditional
 hi def link mdcIO PreProc

--- a/test.masm
+++ b/test.masm
@@ -8,4 +8,4 @@ drawflush
 set
 end
 1sjkks4
-//6467
+#6467


### PR DESCRIPTION
Mindustry Logic uses '#' for its comment syntax, while this plugin uses '//'.